### PR TITLE
Refactor: OneToOne 관계에서 FK 위치 변경으로 N+1 문제 해결, 반정규화로 유저 정보 조회 속도 개선

### DIFF
--- a/src/main/java/knu_chatbot/controller/CreateNewChatRequest.java
+++ b/src/main/java/knu_chatbot/controller/CreateNewChatRequest.java
@@ -1,0 +1,10 @@
+package knu_chatbot.controller;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateNewChatRequest {
+    private String question;
+}

--- a/src/main/java/knu_chatbot/controller/HistoryController.java
+++ b/src/main/java/knu_chatbot/controller/HistoryController.java
@@ -3,6 +3,7 @@ package knu_chatbot.controller;
 import jakarta.validation.Valid;
 import knu_chatbot.controller.request.UpdateHistoryNameRequest;
 import knu_chatbot.controller.response.ApiResponse;
+import knu_chatbot.controller.response.CreateNewChatResponse;
 import knu_chatbot.controller.response.HistoryResponse;
 import knu_chatbot.controller.response.QuestionAndAnswerResponse;
 import knu_chatbot.service.HistoryService;
@@ -36,6 +37,15 @@ public class HistoryController {
             @PathVariable("historyId") Long historyId
     ) {
         return ApiResponse.ok(historyService.getAllQuestionsAndAnswers(memberId, historyId));
+    }
+
+    @PostMapping("/{historyId}")
+    public ApiResponse<CreateNewChatResponse> createNewChatByHistoryId(
+            @SessionAttribute(LOGIN_MEMBER) Long memberId,
+            @PathVariable("historyId") Long historyId,
+            @Valid @RequestBody CreateNewChatRequest request
+    ) {
+        return ApiResponse.ok(historyService.createNewChat(memberId, historyId, request));
     }
 
     @PutMapping("/{historyId}")

--- a/src/main/java/knu_chatbot/controller/response/AnswerResponse.java
+++ b/src/main/java/knu_chatbot/controller/response/AnswerResponse.java
@@ -29,6 +29,6 @@ public class AnswerResponse {
     }
 
     public static AnswerResponse of(Answer answer, List<String> images) {
-        return of(answer.getText(), answer.getReferences(), images);
+        return of(answer.getText(), answer.getReference(), images);
     }
 }

--- a/src/main/java/knu_chatbot/controller/response/CreateNewChatResponse.java
+++ b/src/main/java/knu_chatbot/controller/response/CreateNewChatResponse.java
@@ -1,0 +1,5 @@
+package knu_chatbot.controller.response;
+
+public class CreateNewChatResponse {
+    private String response;
+}

--- a/src/main/java/knu_chatbot/entity/Answer.java
+++ b/src/main/java/knu_chatbot/entity/Answer.java
@@ -22,16 +22,20 @@ public class Answer {
 
     private String text;
 
-    private String references;
+    private String reference;
+
+    @OneToOne
+    @JoinColumn(name = "QUESTION_ID")
+    private Question question;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @Builder.Default
     private List<Image> images = new ArrayList<>();
 
-    public static Answer of(String text, String references) {
+    public static Answer of(String text, String reference) {
         return Answer.builder()
                 .text(text)
-                .references(references)
+                .reference(reference)
                 .build();
     }
 

--- a/src/main/java/knu_chatbot/entity/Answer.java
+++ b/src/main/java/knu_chatbot/entity/Answer.java
@@ -24,8 +24,7 @@ public class Answer {
 
     private String reference;
 
-    @OneToOne
-    @JoinColumn(name = "QUESTION_ID")
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "answer")
     private Question question;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/src/main/java/knu_chatbot/entity/Member.java
+++ b/src/main/java/knu_chatbot/entity/Member.java
@@ -26,6 +26,8 @@ public class Member extends DateTimeEntity {
 
     private String nickname;
 
+    private int questionCount = 0;
+
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<History> histories = new ArrayList<>();
@@ -45,6 +47,10 @@ public class Member extends DateTimeEntity {
 
     public void removeHistory(Long historyId) {
         this.getHistories().removeIf(history -> history.getId().equals(historyId));
+    }
+
+    public void updateQuestionCount(int questionCount) {
+        this.questionCount = questionCount;
     }
 }
 

--- a/src/main/java/knu_chatbot/service/MemberService.java
+++ b/src/main/java/knu_chatbot/service/MemberService.java
@@ -63,10 +63,7 @@ public class MemberService {
 
     public MemberResponse getMyInfo(Long memberId) {
         Member member = findMemberById(memberId);
-
-        int questionCount = memberRepository.countQuestionsByMemberId(memberId);
-
-        return MemberResponse.of(member, questionCount);
+        return MemberResponse.of(member, member.getQuestionCount());
     }
 
     @Transactional


### PR DESCRIPTION
# 1. Question - Answer 간 N+1 문제 해결
## 개요
OneToOne으로 묶인 Question - Answer 간에 N+1 문제 해결

## 배경
* OneToOne으로 묶인 Question - Answer 간에 FK가 Answer단에 있어 Question 조회 시 N+1 문제 발생
* OneToOne 연관관계에서 N+1 문제가 발생하는 상황 참고 : https://dockerel.tistory.com/56

## 변경된 점
* FK를 Question으로 이동
* Question - Answer 간 관계가 추후 1:N으로 확장될 가능성이 없다 판단하여 Question에 FK를 두었음
* 1000건의 Question-Answer 쌍에 대해 510ms &rarr; 122ms로 약 4.2배 속도 향상

## 관련 이슈
close #1

# 2. 반정규화로 유저 정보 조회 속도 개선
## 개요
반정규화로 유저 테이블에 유저 질문 수 필드 추가하여 정보 조회 속도 개선

## 배경
* 마이페이지에서 회원별 질문 개수 조회시, 매번 전체 질문 테이블을 집계하는 쿼리가 발생해 조회 속도가 느려지고 DB에 부하 누적

## 변경된 점
* 이를 해결하기 위해 questionCount 컬럼을 member 테이블에 별도로 저장하는 반정규화 구조로 변경
* 배치 작업을 통해 매일 저장된 questionCount와 실제 질문 개수가 일치하는지 정기적으로 검증하여 데이터 무결성을 보장
* 조회 속도를 1.6s에서 132ms로 약 90% 개선하고 배치 검증으로 데이터 정합성까지 보장

## 관련 이슈
close #-